### PR TITLE
Updates awards for 2019, 2021 (missing 2021 MIP)

### DIFF
--- a/awards/index.html
+++ b/awards/index.html
@@ -22,6 +22,25 @@ rel="stylesheet" type="text/css">
       <p>
       <em>The  <a  class="extern" href="http://programming-journal.org">Programming Journal</a> hands out <a class="extern" href="http://programming-journal.org/awards/">awards to celebrate the work of the community</a> around the journal.</em>
       </p>
+      
+      <h2>2021</h2>
+      <h3>‹Programming› 2021</h3>
+      <!--<ul>
+        <li>Most influential paper award: <em>TODO (AOSD 2011)</li>
+        <li>Most influential paper award: <em>TODO (AOSD 2010)</li>
+      </ul>-->
+      <h3>Outstanding Service Award</h3>
+      <ul>
+        <li>Outstanding service awardees: Tobias Pape</li>
+        <li>Outstanding service awardees: Patrick Rein</li>
+      </ul>
+      
+      <h2>2019</h2>
+      <h3>‹Programming› 2019</h3>
+      <ul>
+        <li>Most influential paper award: <em>Can We Refactor Conditional Compilation into Aspects?</em> by Bram Adams, Wolfgang De Meuter, Herman Tromp, Ahmed Hassan (AOSD 2009)</li>
+      </ul>
+            
       <h2>2018</h2>
       <h3>‹Programming› 2018</h3>
       <ul>

--- a/awards/index.html
+++ b/awards/index.html
@@ -25,10 +25,10 @@ rel="stylesheet" type="text/css">
       
       <h2>2021</h2>
       <h3>‹Programming› 2021</h3>
-      <!--<ul>
-        <li>Most influential paper award: <em>TODO (AOSD 2011)</li>
-        <li>Most influential paper award: <em>TODO (AOSD 2010)</li>
-      </ul>-->
+      <ul>
+        <li>Most influential paper award: <em>Reducing Combinatorics in Testing Product Lines</em> by Chang Hwan Peter Kim, Don Batory, and Sarfraz Khurshid (AOSD 2011)</li>
+        <li>Most influential paper award: <em>Execution Levels for Aspect-Oriented Programming</em> by Éric Tanter (AOSD 2010)</li>
+      </ul>
       <h3>Outstanding Service Award</h3>
       <ul>
         <li>Outstanding service awardees: Tobias Pape</li>


### PR DESCRIPTION
I still have to determine the 2021 MIP. No idea were that is. Probably I do not have it in the archive yet. :P